### PR TITLE
Updated write_reg_multi_bytes in nrf.py

### DIFF
--- a/nRF24_BDADDR_Sniffer/nrf.py
+++ b/nRF24_BDADDR_Sniffer/nrf.py
@@ -62,7 +62,7 @@ class NRF24BREDR(object):
         self.spi.xfer2([W_REGISTER | (REGISTER_MASK & reg), value])
     
     def write_reg_multi_bytes(self, reg, data, pad_len):
-        write = list(data.ljust(pad_len, b'\x00'))
+        write = [ord(i) for i in data.ljust(pad_len, b'\x00')]
         self.spi.xfer2([W_REGISTER | (REGISTER_MASK & reg)] + write)
 
     def read_reg(self, reg, size=1):


### PR DESCRIPTION
list() generates a string array causing the following exception:

Traceback (most recent call last):
  File "nrf.py", line 183, in <module>
    main(*sys.argv[1:])
  File "nrf.py", line 152, in main
    nrf.setup(int(chan) if chan else 0)
  File "nrf.py", line 96, in setup
    self.write_reg_multi_bytes(RX_ADDR_P0, PROMISC_MAC[::-1], RX_PIPE_MAC_LEN)
  File "nrf.py", line 66, in write_reg_multi_bytes
    self.spi.xfer2([W_REGISTER | (REGISTER_MASK & reg)] + write)
TypeError: Non-Int/Long value in arguments: b6cbf368.